### PR TITLE
Add Suppress Limit option #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Options:
   -i, --identifiers                  match identifiers
   -c, --config                       path to config file (default: .jsinspectrc)
   -r, --reporter [default|json|pmd]  specify the reporter to use
+  -s, --suppress-limit <number>      on which count of lines diff should be suppressed, (default: 100, nolimit: 0)
   -D, --no-diff                      disable 2-way diffs
   -C, --no-color                     disable colors
   --ignore <pattern>                 ignore paths matching a regex
@@ -78,10 +79,11 @@ be used in place of the defaults listed above. For example:
 
 ``` javascript
 {
-  "threshold":   30,
-  "identifiers": true,
-  "ignore":      "Test.js|Spec.js" // used as RegExp,
-  "reporter":    "json"
+  "threshold":     30,
+  "identifiers":   true,
+  "ignore":        "Test.js|Spec.js", // used as RegExp,
+  "reporter":      "json",
+  "suppressLinit": 100
 }
 ```
 

--- a/bin/jsinspect
+++ b/bin/jsinspect
@@ -27,11 +27,13 @@ program
     'specify the reporter to use')
   .option('-D, --no-diff', 'disable 2-way diffs')
   .option('-C, --no-color', 'disable colors')
+  .option('-s, --suppress-limit <number>',
+    'on which count of lines diff should be suppressed, (default: 100, nolimit: 0)', parseInt)
   .option('--ignore <pattern>', 'ignore paths matching a regex')
   .parse(process.argv);
 
 // Check and parse the config file, if it exists
-var rcPath, rcContents, rc, opt;
+var rcPath, rcContents, rc, opts;
 rcPath = path.resolve(process.cwd(), program.config || '.jsinspectrc');
 opts = {encoding: 'utf8'};
 
@@ -44,7 +46,7 @@ if (fs.existsSync(rcPath) && fs.lstatSync(rcPath).isFile()) {
     process.exit(1);
   }
 
-  ['threshold', 'identifiers', 'ignore', 'reporter'].forEach(function(option) {
+  ['threshold', 'identifiers', 'ignore', 'reporter', 'suppressLimit'].forEach(function(option) {
     if (program[option] === undefined && (option in rc)) {
       program[option] = rc[option];
     }
@@ -94,6 +96,7 @@ inspector = new Inspector(paths, {
 reporterType = reporters[program.reporter] || reporters.default;
 new reporterType(inspector, {
   diff: program.diff,
+  suppressLimit: program.suppressLimit
 });
 
 try {

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -16,6 +16,7 @@ function BaseReporter(inspector, opts) {
 
   this._inspector = inspector;
   this._found = 0;
+  this._suppressLimit = !opts.suppressLimit ? (opts.suppressLimit === 0 ? 0 : 100) : opts.suppressLimit;
   this._registerListener();
 }
 
@@ -43,7 +44,7 @@ BaseReporter.prototype._registerListener = function() {
 BaseReporter.prototype._registerSummary = function() {
   var self = this;
   this._inspector.on('end', function() {
-    var summary, files, match, numFiles;
+    var summary, files, matches, numFiles;
 
     numFiles = self._inspector.numFiles;
     files = (numFiles > 1) ? 'files' : 'file';
@@ -85,8 +86,8 @@ BaseReporter.prototype._getFormattedDiff = function(diff) {
     }
 
     diffLength += lines.length;
-    if (diffLength > 100) {
-      return 'Diff suppressed as it surpasses 100 lines\n';
+    if (this._suppressLimit && diffLength > this._suppressLimit) {
+      return 'Diff suppressed as it surpasses ' + this._suppressLimit + ' lines\n';
     }
 
     for (j = 0; j < lines.length; j++) {


### PR DESCRIPTION
I have added an option for controlling suppress limit : ) As i asked in Issue #12. Now it's possible to control how many lines should be suppressed by setting -s or --suppress-limit option. If you set -s 0 you will not have limit at all. By default it is 100 like it was before.
