### PR TITLE
Allow duplications to be identified by a hash key

### DIFF
--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -133,7 +133,7 @@ Inspector.prototype._analyze = function() {
     for (i = 0; i < nodes.length; i++) {
       if (nodes[i].length < 2) continue;
 
-      match = new Match(nodes[i]);
+      match = new Match(nodes[i], key);
       if (this._diff) {
         match.generateDiffs(this._fileContents);
       }

--- a/lib/match.js
+++ b/lib/match.js
@@ -1,5 +1,6 @@
 var jsdiff = require('diff');
 var strip = require('strip-indent');
+var crypto = require('crypto');
 
 /**
  * Creates a new Match, consisting of an array of nodes. If generated, an
@@ -9,9 +10,11 @@ var strip = require('strip-indent');
  *
  * @param {Node[]} nodes An array of matching nodes
  */
-function Match(nodes) {
+function Match(nodes, key) {
   this.nodes = nodes;
   this.diffs = [];
+  this._key  = key || '';
+  this.hash  = crypto.createHash('sha1').update(this._key).digest('hex');
 }
 
 module.exports = Match;

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -54,7 +54,7 @@ JSONReporter.prototype._getOutput = function(match) {
 
   self = this;
   output = '';
-  formatted = {instances: []};
+  formatted = {id: match.hash, instances: []};
 
   nodes = match.nodes;
   nodes.forEach(function(node) {

--- a/lib/reporters/pmd.js
+++ b/lib/reporters/pmd.js
@@ -62,7 +62,7 @@ PMDReporter.prototype._getOutput = function(match) {
     output += '\n';
   }
 
-  output += '<duplication lines="' + this._getTotalLines(nodes) + '">\n';
+  output += '<duplication lines="' + this._getTotalLines(nodes) + '" id="' + match.hash + '">\n';
   nodes.forEach(function(node) {
     output += self._getFile(node);
   });

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -19,6 +19,14 @@ module.exports = {
     };
   },
 
+  collectMatches: function(inspector) {
+    var array = [];
+    inspector.on('match', function(match) {
+      array.push(match);
+    });
+    return array;
+  },
+
   getOutput: function() {
     return output;
   },

--- a/spec/matchSpec.js
+++ b/spec/matchSpec.js
@@ -12,13 +12,26 @@ describe('Match', function() {
         {type: 'Literal'}
       ];
 
-      var match = new Match(mockNodes);
+      var match = new Match(mockNodes, 'key');
       expect(match.nodes).to.be(mockNodes);
     });
 
     it('initializes the object with an empty array for match.diffs', function() {
-      var match = new Match([]);
+      var match = new Match([], '');
       expect(match.diffs).to.eql([]);
+    });
+  });
+
+  describe('hash', function() {
+    it('returns a different hash for different key', function() {
+      var match1 = new Match([], 'a');
+      var match2 = new Match([], 'b');
+      expect(match1.hash).not.to.equal(match2.hash);
+    });
+    it('returns a same hash for same key', function() {
+      var match1 = new Match([], 'a');
+      var match2 = new Match([], 'a');
+      expect(match1.hash).to.equal(match2.hash);
     });
   });
 

--- a/spec/reporters/jsonSpec.js
+++ b/spec/reporters/jsonSpec.js
@@ -39,6 +39,7 @@ describe('JSONReporter', function() {
         threshold: 1
       });
       var reporter = new JSONReporter(inspector);
+      var matches = helpers.collectMatches(inspector);
 
       inspector.removeAllListeners('start');
       inspector.removeAllListeners('end');
@@ -48,6 +49,7 @@ describe('JSONReporter', function() {
 
       var parsedOutput = JSON.parse(helpers.getOutput());
       expect(parsedOutput).to.eql({
+        id: matches[0].hash,
         instances: [
           {path: 'spec/fixtures/smallDiffs.js', lines: [1,1]},
           {path: 'spec/fixtures/smallDiffs.js', lines: [2,2]},
@@ -97,11 +99,13 @@ describe('JSONReporter', function() {
     var reporter = new JSONReporter(inspector, {
       writableStream: concatStream
     });
+    var matches = helpers.collectMatches(inspector);
 
     inspector.run();
 
     function onFinish(data) {
       expect(JSON.parse(data)).to.eql([{
+        id: matches[0].hash,
         instances: [
           {path: 'spec/fixtures/smallDiffs.js', lines: [1,1]},
           {path: 'spec/fixtures/smallDiffs.js', lines: [2,2]},

--- a/spec/reporters/pmdSpec.js
+++ b/spec/reporters/pmdSpec.js
@@ -23,10 +23,11 @@ describe('PMDReporter', function() {
     });
 
     it('prints paths and line numbers in a duplication element', function() {
-      var inspector, reporter;
+      var inspector, reporter, matches;
 
       inspector = new Inspector([fixtures.smallDiffs], {threshold: 1});
       reporter = new PMDReporter(inspector);
+      matches = helpers.collectMatches(inspector);
 
       inspector.removeAllListeners('start');
       inspector.removeAllListeners('end');
@@ -35,7 +36,7 @@ describe('PMDReporter', function() {
       helpers.restoreOutput();
 
       expect(helpers.getOutput()).to.eql(
-        '<duplication lines=\"3\">\n' +
+        '<duplication lines=\"3\" id="' + matches[0].hash + '">\n' +
         '<file path=\"' + fixtures.smallDiffs + '\" line=\"1\"/>\n' +
         '<file path=\"' + fixtures.smallDiffs + '\" line=\"2\"/>\n' +
         '<file path=\"' + fixtures.smallDiffs + '\" line=\"3\"/>\n' +
@@ -45,13 +46,14 @@ describe('PMDReporter', function() {
     });
 
     it('prints diffs if enabled, within a codefragment element', function() {
-      var inspector, reporter, absolutePath;
+      var inspector, reporter, absolutePath, matches;
 
       inspector = new Inspector([fixtures.smallDiffs], {
         diff: true,
         threshold: 1
       });
       reporter = new PMDReporter(inspector, {diff: true});
+      matches = helpers.collectMatches(inspector);
 
       inspector.removeAllListeners('start');
       inspector.removeAllListeners('end');
@@ -60,7 +62,7 @@ describe('PMDReporter', function() {
       helpers.restoreOutput();
 
       expect(helpers.getOutput()).to.eql(
-        '<duplication lines=\"3\">\n' +
+        '<duplication lines=\"3\" id="' + matches[0].hash + '">\n' +
         '<file path=\"' + fixtures.smallDiffs + '\" line=\"1\"/>\n' +
         '<file path=\"' + fixtures.smallDiffs + '\" line=\"2\"/>\n' +
         '<file path=\"' + fixtures.smallDiffs + '\" line=\"3\"/>\n' +


### PR DESCRIPTION
This allows automated scripts to parse the resulting JSON/XML file and detect new/removed duplications. This can also potentially solve #27 by ignoring matches with a specific hash key.