### PR TITLE
Add jsx option support in .jsinspectrc

### DIFF
--- a/bin/jsinspect
+++ b/bin/jsinspect
@@ -48,7 +48,7 @@ if (fs.existsSync(rcPath) && fs.lstatSync(rcPath).isFile()) {
     process.exit(1);
   }
 
-  ['threshold', 'identifiers', 'ignore',
+  ['threshold', 'identifiers', 'ignore', 'jsx',
    'reporter', 'suppress'].forEach(function(option) {
     if (program[option] === undefined && (option in rc)) {
       program[option] = rc[option];


### PR DESCRIPTION
This PR address issue https://github.com/danielstjules/jsinspect/issues/32. With this change, the `jsx` option can be defined in the `.jsinspectrc` file.