### PR TITLE
Update --jsx option help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Options:
   -V, --version                      output the version number
   -t, --threshold <number>           number of nodes (default: 15)
   -i, --identifiers                  match identifiers
-  -j  --jsx                          process jsx files (default off)
+  -j, --jsx                          process jsx files (default: false)
   -c, --config                       path to config file (default: .jsinspectrc)
   -r, --reporter [default|json|pmd]  specify the reporter to use
   -s, --suppress <number>            length to suppress diffs (default: 100, off: 0)

--- a/bin/jsinspect
+++ b/bin/jsinspect
@@ -21,7 +21,7 @@ program
   .option('-t, --threshold <number>',
     'number of nodes (default: 15)', parseInt)
   .option('-i, --identifiers', 'match identifiers')
-  .option('-j --jsx', 'support jsx files')
+  .option('-j, --jsx', 'support jsx files (default: false)')
   .option('-c, --config',
     'path to config file (default: .jsinspectrc)')
   .option('-r, --reporter [default|json|pmd]',


### PR DESCRIPTION
Update the `jsinspect --help` output to show the same verbiage for the `--jsx` option as the README file. Provide clarification for the default value as well.