### PR TITLE
Use exitCode over process.exit()

### DIFF
--- a/bin/jsinspect
+++ b/bin/jsinspect
@@ -108,8 +108,8 @@ inspector.on('match', () => matches++);
 
 try {
   inspector.run();
-  process.exit(matches ? 5 : 0);
+  process.exitCode = matches ? 5 : 0;
 } catch(err) {
   console.log(err);
-  process.exit(1);
+  process.exitCode = 1;
 }


### PR DESCRIPTION
Hi @danielstjules, thanks for this great package. 

I've run into an issue where if I run jsinspect from a node child-process I'm not getting the full stdout output.

Here's a bit of code I was running:
```js
const exec = require('child_process').exec;

const jsinspect = exec(
  "node ./node_modules/.bin/jsinspect --no-literals --min-instances 3 --ignore 'coverage|dist|flow-typed' .",
  {
    maxBuffer: 1024 * 1000,
    encoding: 'utf8',
  },
  (error, stdout) => {
    console.log('stdout', stdout, 'done');
  },
);
```

When I run this without the change it terminates BEFORE all output is flushed, after the change, all output is there.


It doesn't seem to be consistent across all machines I've tested this on, please don't just close with 'cannot reproduce'. It might need a minimum amount of output and a specific timing for the issue to occur. `27 matches found across 425 files` on in my machine `2.49s user 0.43s system 110% cpu 2.644 total`.

my system info
```
macOS 10.12.6 (16G1114)
Model Name:	MacBook Pro
Model Identifier:	MacBookPro11,3
Processor Name:	Intel Core i7
Processor Speed:	2,5 GHz
Number of Processors:	1
Total Number of Cores:	4
L2 Cache (per Core):	256 KB
L3 Cache:	6 MB
Memory:	16 GB
```

Please let me know what I can do to help / clarify further.