### PR TITLE
Added esdoc config

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -1,0 +1,50 @@
+{
+  "source": "./lib",
+  "destination": "./docs",
+  "includes": ["\\.js$"],
+  "excludes": [],
+  "index": "./README.md",
+  "package": "./package.json",
+  "plugins": [
+    {
+      "name": "esdoc-standard-plugin",
+      "option": {
+        "lint": {"enable": true},
+        "coverage": {"enable": true},
+        "accessor": {"access": ["public", "protected", "private"], "autoPrivate": true},
+        "undocumentIdentifier": {"enable": false},
+        "unexportedIdentifier": {"enable": true},
+        "typeInference": {"enable": true},
+        "brand": {
+          "logo": "",
+          "title": "jsinspect",
+          "description": "jsinspect",
+          "repository": "https://github.com/danielstjules/jsinspect",
+          "site": "",
+          "author": "https://github.com/danielstjules",
+          "image": "https://github.com/danielstjules/logo.png"
+        },
+        "test": {
+          "source": "./spec/",
+          "interfaces": ["describe", "it", "context", "suite", "test"],
+          "includes": ["(spec|Spec|test|Test)\\.js$"],
+          "excludes": ["\\.config\\.js$"]
+        }
+      }
+    },
+    {
+      "name": "esdoc-ecmascript-proposal-plugin",
+      "option": {
+        "classProperties": true,
+        "objectRestSpread": true,
+        "doExpressions": true,
+        "functionBind": true,
+        "functionSent": true,
+        "asyncGenerators": true,
+        "decorators": true,
+        "exportExtensions": true,
+        "dynamicImport": true
+      }
+    }
+  ]
+}

--- a/lib/inspector.js
+++ b/lib/inspector.js
@@ -7,6 +7,9 @@ var NodeUtils    = require('./nodeUtils');
 var crypto       = require('crypto');
 var stable       = require('stable');
 
+/**
+ *
+ */
 class Inspector extends EventEmitter {
   /**
    * Creates a new Inspector, which extends EventEmitter. filePaths is expected

--- a/lib/match.js
+++ b/lib/match.js
@@ -2,6 +2,9 @@ var strip     = require('strip-indent');
 var crypto    = require('crypto');
 var NodeUtils = require('./nodeUtils');
 
+/**
+ *
+ */
 class Match {
   /**
    * Creates a new Match.

--- a/lib/nodeUtils.js
+++ b/lib/nodeUtils.js
@@ -12,6 +12,9 @@ var childKeys = {
   JSXAttribute: ['name', 'value'],
 };
 
+/**
+ *
+ */
 class NodeUtils {
   /**
    * Walks a root node's subtrees using DFS, invoking the passed callback with

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -2,6 +2,9 @@ var util  = require('util');
 var path  = require('path');
 var chalk = require('chalk');
 
+/**
+ *
+ */
 class BaseReporter {
   /**
    * A base reporter from which all others inherit. Registers a listener on the

--- a/lib/reporters/default.js
+++ b/lib/reporters/default.js
@@ -2,6 +2,9 @@ var util         = require('util');
 var chalk        = require('chalk');
 var BaseReporter = require('./base');
 
+/**
+ *
+ */
 class DefaultReporter extends BaseReporter {
   /**
    * The default reporter, which displays both file and line information for

--- a/lib/reporters/json.js
+++ b/lib/reporters/json.js
@@ -3,6 +3,9 @@ var path         = require('path');
 var chalk        = require('chalk');
 var BaseReporter = require('./base');
 
+/**
+ *
+ */
 class JSONReporter extends BaseReporter {
   /**
    * A JSON reporter, which displays both file and line information for

--- a/lib/reporters/pmd.js
+++ b/lib/reporters/pmd.js
@@ -3,6 +3,9 @@ var path         = require('path');
 var chalk        = require('chalk');
 var BaseReporter = require('./base');
 
+/**
+ *
+ */
 class PMDReporter extends BaseReporter {
   /**
    * A PMD CPD XML reporter, which tries to fit jsinspect's output to something

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "devDependencies": {
     "concat-stream": "^1.5.0",
     "dirmap": "^0.0.2",
+    "esdoc": "^1.0.4",
+    "esdoc-ecmascript-proposal-plugin": "^1.0.0",
+    "esdoc-standard-plugin": "^1.0.0",
     "expect.js": "^0.3.1",
     "mocha": "^3.5.0"
   },
@@ -37,6 +40,8 @@
     "jsinspect": "./bin/jsinspect"
   },
   "scripts": {
-    "test": "mocha -R spec spec spec/reporters"
+    "test": "mocha -R spec spec spec/reporters",
+    "docs": "./node_modules/.bin/esdoc",
+    "docs-open": "npm run docs && open docs/index.html"
   }
 }


### PR DESCRIPTION
This PR adds a basic esdoc config to build the docs of the lib directory. the build can be triggered with the `npm run docs` command.

A generated preview can be found here: https://paulvollmer.net/jsinspect/docs
files here: https://github.com/paulvollmer/jsinspect/tree/gh-pages/docs