### PR TITLE
add options.lineNumber & markdown reporter

### DIFF
--- a/bin/jsinspect
+++ b/bin/jsinspect
@@ -49,7 +49,7 @@ if (fs.existsSync(rcPath) && fs.lstatSync(rcPath).isFile()) {
   }
 
   ['threshold', 'identifiers', 'literals', 'ignore', 'minInstances',
-   'reporter', 'truncate'].forEach((option) => {
+   'reporter', 'truncate', 'lineNumber'].forEach((option) => {
     if (program[option] === undefined && (option in rc)) {
       program[option] = rc[option];
     }
@@ -99,7 +99,8 @@ var inspector = new Inspector(paths, {
 // Retrieve the requested reporter
 var reporterType = reporters[program.reporter] || reporters.default;
 new reporterType(inspector, {
-  truncate: program.truncate
+  truncate: program.truncate,
+  lineNumber: program.lineNumber
 });
 
 // Track the number of matches

--- a/lib/reporters/base.js
+++ b/lib/reporters/base.js
@@ -18,6 +18,7 @@ class BaseReporter {
     this._inspector = inspector;
     this._found = 0;
     this._truncate = (opts.truncate === 0) ? 0 : (opts.truncate || 100);
+    this._lineNumber = !!opts.lineNumber;
     this._writableStream = opts.writableStream || process.stdout;
     this._registerListener();
 
@@ -83,12 +84,17 @@ class BaseReporter {
    * @returns {string}
    */
   _getLines(instance) {
-    var lines = instance.lines;
+    var lines = instance.lines.split('\n');
+    var start = instance.start.line;
+    var end = instance.end.line;
+    if (this._lineNumber) {
+      lines = lines.map((l,i) => `${prettyLineNum(i, start, end)} │ ${l}`);
+    }
     if (this._truncate) {
-      lines = lines.split('\n').slice(0, this._truncate).join('\n');
+      lines = lines.slice(0, this._truncate);
     }
 
-    return lines;
+    return lines.join('\n');
   }
 
   /**
@@ -118,6 +124,18 @@ class BaseReporter {
 
     return filePath;
   }
+}
+
+function prettyLineNum(index, start, end) {
+  let res = `${start + index}`;
+  let ln = res.length;
+  let ls = `${start}`.length;
+  let le = `${end}`.length;
+  let i = le -ln;
+  while (i--) {
+    res += ' ';
+  }
+  return res;
 }
 
 module.exports = BaseReporter;

--- a/lib/reporters/index.js
+++ b/lib/reporters/index.js
@@ -1,5 +1,8 @@
+let MDReporter = require('./md.js');
 module.exports = {
-  default: require('./default.js'),
-  json:    require('./json.js'),
-  pmd:     require('./pmd.js')
+  default:  require('./default.js'),
+  json:     require('./json.js'),
+  pmd:      require('./pmd.js'),
+  md:       MDReporter,
+  markdown: MDReporter,
 };

--- a/lib/reporters/md.js
+++ b/lib/reporters/md.js
@@ -1,0 +1,72 @@
+let chalk        = require('chalk');
+let BaseReporter = require('./base');
+
+class MdReporter extends BaseReporter {
+  /**
+   * A Markdown reporter, which tries to fit jsinspect's output to something
+   *
+   * @constructor
+   *
+   * @param {Inspector} inspector Instance on which to register its listeners
+   * @param {object}    opts      Options to set for the reporter
+   */
+  constructor(inspector, opts) {
+    opts = opts || {};
+    super(inspector, opts);
+
+    const enabled = chalk.enabled;
+
+    inspector.on('start', () => {
+      chalk.enabled = false;
+      this._writableStream.write(
+        `\n## Check report (via [Jsinspect](https://github.com/danielstjules/jsinspect))\n\n`
+      );
+    });
+
+    inspector.on('end', () => {
+      chalk.enabled = enabled;
+      this._writableStream.write('\n');
+    });
+  }
+
+  /**
+   * Returns an Markdown string
+   *
+   * @private
+   *
+   * @param   {Match}  match The inspector match to output
+   * @returns {string} The formatted output
+   */
+  _getOutput(match) {
+    let output = (this._found > 1) ? '\n' : '';
+    let codeFragment = '';
+    let instances = match.instances;
+    let totalLines = this._getTotalLines(match);
+
+    output += `#### ID: *${match.hash}*,  Duplicate-Lines: ${totalLines}\n\n`;
+    instances.forEach((instance) => output += `- ${instance.filename}: ${instance.start.line}\n`);
+
+    output += '\n\`\`\`js';
+    let lastIndex = instances.length - 1;
+    instances.forEach((instance, index) => {
+      let location = this._getFormattedLocation(instance);
+      let lines = this._getLines(instance);
+      codeFragment += `\n// ${location}\n${chalk.grey(lines)}${index === lastIndex ? '' : '\n'}`;
+    });
+    output += `${codeFragment}\n\`\`\`\n\n---\n\n`;
+
+    return output;
+  }
+
+  /**
+   * Returns the total number of lines spanned by a match.
+   *
+   * @param   {Match} match
+   * @returns {int}
+   */
+  _getTotalLines(match) {
+    return match.instances.reduce((res, curr) => (res + curr.end.line - curr.start.line + 1), 0);
+  }
+}
+
+module.exports = MdReporter;

--- a/spec/reporters/mdSpec.js
+++ b/spec/reporters/mdSpec.js
@@ -1,0 +1,67 @@
+var expect      = require('expect.js');
+var util        = require('util');
+var chalk       = require('chalk');
+var fixtures    = require('../fixtures');
+var helpers     = require('../helpers');
+var MdReporter = require('../../lib/reporters/md');
+var Inspector   = require('../../lib/inspector');
+
+describe('MdReporter', function() {
+  afterEach(function() {
+    helpers.restoreOutput();
+  });
+
+  describe('constructor', function() {
+    it('accepts an inspector as an argument', function() {
+      var inspector, reporter;
+
+      inspector = new Inspector(['']);
+      reporter = new MdReporter(inspector);
+      expect(reporter._inspector).to.be(inspector);
+    });
+  });
+
+  describe('given a match', function() {
+    beforeEach(function() {
+      helpers.captureOutput();
+    });
+
+    it('prints correct with markdown reporter', function() {
+      var inspector, reporter, matches;
+
+      inspector = new Inspector([fixtures.smallLines], {threshold: 1});
+      reporter = new MdReporter(inspector);
+      matches = helpers.collectMatches(inspector);
+
+      inspector.removeAllListeners('start');
+      inspector.removeAllListeners('end');
+
+      inspector.run();
+      helpers.restoreOutput();
+
+      var expected = helpers.trimlines(
+        `#### ID: *${matches[0].hash}*,  Duplicate-Lines: 3
+        
+        - ${fixtures.smallLines}: 1        
+        - ${fixtures.smallLines}: 2        
+        - ${fixtures.smallLines}: 3
+        
+        \`\`\`js
+        // spec/fixtures/smallLines.js:1,1
+        test = function() { return 1; };
+
+        // spec/fixtures/smallLines.js:2,2
+        test = function() { return 2; };
+
+        // spec/fixtures/smallLines.js:3,3
+        test = function() { return 3; };
+        \`\`\`
+        
+        ---
+        
+        `);
+
+      expect(helpers.getOutput()).to.eql(expected);
+    });
+  });
+});


### PR DESCRIPTION
This PR offer 2 cases:
1. Add options.lineNumber for print out
file `.jsinspectrc`
```js
{
  "lineNumber": true
}
```
result:
```js
./src/index.js:62,65
62 │ methods: {
63 │     hahahaha() {
64 │         return (n) => {
65 │             if(!n) {
```
2. Add a new reporter (named 'md' or 'markdown') to support markdown
file `.jsinspectrc`
```js
{
  "lineNumber": true,
  "reporter": "md" // or "markdown"
}
```
u can use cmd like

```sh
jsinspect > ./your/path/check-report.md
```
to gen a *.md file